### PR TITLE
warning count cache issue fixed

### DIFF
--- a/apps/server/src/cache/redis.cache.ts
+++ b/apps/server/src/cache/redis.cache.ts
@@ -82,28 +82,57 @@ export default class RedisCache {
 
     //  <------------------ PARTICIPANT ------------------>
 
-    public async get_participant(game_session_id: string, participant_id: string) {
-        const key = this.get_participants_key(game_session_id);
+    public async get_participant(
+        game_session_id: string,
+        participant_id: string,
+    ): Promise<Participant | null> {
+        const participant_key = this.get_participants_key(game_session_id);
         try {
-            const data = await this.redis_cache.hget(key, participant_id);
-            return data ? JSON.parse(data) : null;
+            const data = await this.redis_cache.hgetall(participant_key);
+            if (!data) return null;
+            const participant: Record<string, unknown> = {};
+            const field_prefix = `${participant_id}:`;
+
+            Object.entries(data).forEach(([field, value]) => {
+                if (field.startsWith(field_prefix)) {
+                    const field_name = field.slice(field_prefix.length);
+                    try {
+                        participant[field_name] = JSON.parse(value);
+                    } catch {
+                        participant[field_name] = value;
+                    }
+                }
+            });
+            return Object.keys(participant).length > 0 ? (participant as Participant) : null;
         } catch (err) {
-            console.error('Error in get_participant:', err);
+            console.error('Error in get_participant :', err);
             return null;
         }
     }
 
     public async get_all_participants(game_session_id: string, fields?: (keyof Participant)[]) {
-        const key = this.get_participants_key(game_session_id);
+        const participant_key = this.get_participants_key(game_session_id);
         try {
-            const data = await this.redis_cache.hgetall(key);
-            if (!data) return [];
+            const data = await this.redis_cache.hgetall(participant_key);
+            if (!data || Object.keys(data).length === 0) return [];
 
-            return Object.entries(data).map(([id, value]) => {
-                const participant = JSON.parse(value);
+            const participants_map: Record<string, Record<string, unknown>> = {};
 
+            Object.entries(data).forEach(([field, value]) => {
+                const [participant_id, field_name] = field.split(':');
+                if (!participants_map[participant_id]) {
+                    participants_map[participant_id] = {};
+                }
+                try {
+                    participants_map[participant_id][field_name] = JSON.parse(value);
+                } catch {
+                    participants_map[participant_id][field_name] = value;
+                }
+            });
+
+            return Object.entries(participants_map).map(([id, participant]) => {
                 if (fields && fields.length > 0) {
-                    const filtered: any = { id };
+                    const filtered: Record<string, unknown> = { id };
                     for (const field of fields) {
                         if (participant[field] !== undefined) {
                             filtered[field] = participant[field];
@@ -111,24 +140,31 @@ export default class RedisCache {
                     }
                     return filtered;
                 }
-
                 return { id, ...participant };
             });
         } catch (err) {
-            console.error('Error in get_all_participants:', err);
+            console.error('Error in get_all_participants_v2:', err);
             return [];
         }
     }
 
-    public async set_participants(
+    public async set_participant(
         game_session_id: string,
         participant_id: string,
         particpant: Partial<Participant>,
     ) {
         try {
-            const key = this.get_participants_key(game_session_id);
-            await this.redis_cache.hset(key, participant_id, JSON.stringify(particpant));
-            await this.redis_cache.expire(key, 60 * 60 * 24);
+            const participant_key = this.get_participants_key(game_session_id);
+            const pipeline = this.redis_cache.pipeline();
+
+            Object.entries(particpant).forEach(([field, value]) => {
+                const field_key = `${participant_id}:${field}`;
+                const field_value = typeof value === 'string' ? value : JSON.stringify(value);
+                pipeline.hset(participant_key, field_key, field_value);
+            });
+
+            await pipeline.exec();
+            await this.redis_cache.expire(participant_key, 60 * 60 * 24);
         } catch (err) {
             console.error('Error while setting participant in cache : ', err);
         }
@@ -137,9 +173,23 @@ export default class RedisCache {
     public async delete_participant(game_session_id: string, participant_id: string) {
         const key = this.get_participants_key(game_session_id);
         try {
-            await this.redis_cache.hdel(key, participant_id);
+            const data = await this.redis_cache.hgetall(key);
+            if (!data) return;
+
+            const fields_to_delete: string[] = [];
+            const prefix = `${participant_id}:`;
+
+            for (const field of Object.keys(data)) {
+                if (field.startsWith(prefix)) {
+                    fields_to_delete.push(field);
+                }
+            }
+
+            if (fields_to_delete.length > 0) {
+                await this.redis_cache.hdel(key, ...fields_to_delete);
+            }
         } catch (error) {
-            console.error('Error in delete-participant: ', error);
+            console.error('Error in delete_participant:', error);
         }
     }
 

--- a/apps/server/src/controllers/live-quiz-controller/participantJoinController.ts
+++ b/apps/server/src/controllers/live-quiz-controller/participantJoinController.ts
@@ -9,7 +9,7 @@ import { env } from '../../configs/env';
 
 export default async function participantJoinController(req: Request, res: Response) {
     const parseResult = participantJoinSchema.safeParse(req.body);
-    const redisCache = redisCacheInstance;
+    const redis_cache = redisCacheInstance;
     if (!parseResult.success) {
         res.status(400).json({
             success: false,
@@ -79,7 +79,7 @@ export default async function participantJoinController(req: Request, res: Respo
                 },
             });
 
-            redisCache.set_participants(gameSession.id, participant.id, participant);
+            redis_cache.set_participant(gameSession.id, participant.id, participant);
 
             await tx.gameSession.update({
                 where: { id: gameSession.id },

--- a/apps/server/src/queue/DatabaseQueue.ts
+++ b/apps/server/src/queue/DatabaseQueue.ts
@@ -12,7 +12,7 @@ import {
     Interactions,
     Response,
 } from '@nocturn/database';
-import RedisCache from '../cache/RedisCache';
+import RedisCache from '../cache/redis.cache';
 import { redisCacheInstance } from '../services/init-services';
 import { ReactorType } from '@nocturn/types';
 import { env } from '../configs/env';
@@ -207,7 +207,7 @@ export default class DatabaseQueue {
                 },
                 data: participant,
             });
-            await this.redis_cache.set_participants(
+            await this.redis_cache.set_participant(
                 game_session_id,
                 updatedParticipant.id,
                 updatedParticipant,

--- a/apps/server/src/queue/PhaseQueue.ts
+++ b/apps/server/src/queue/PhaseQueue.ts
@@ -1,5 +1,5 @@
 import Bull from 'bull';
-import RedisCache from '../cache/RedisCache';
+import RedisCache from '../cache/redis.cache';
 import { redisCacheInstance } from '../services/init-services';
 import QuizManager from '../sockets/QuizManager';
 import { PhaseTransitionJob } from '../types/web-socket-types';

--- a/apps/server/src/services/init-services.ts
+++ b/apps/server/src/services/init-services.ts
@@ -1,4 +1,4 @@
-import RedisCache from '../cache/RedisCache';
+import RedisCache from '../cache/redis.cache';
 import DatabaseQueue from '../queue/DatabaseQueue';
 import QuizController from '../controllers/quiz-controller/quizController';
 import PhaseQueue from '../queue/PhaseQueue';

--- a/apps/server/src/sockets/HostManager.ts
+++ b/apps/server/src/sockets/HostManager.ts
@@ -22,7 +22,7 @@ import {
 import { v4 as uuid } from 'uuid';
 import { WebSocket } from 'ws';
 import DatabaseQueue from '../queue/DatabaseQueue';
-import RedisCache from '../cache/RedisCache';
+import RedisCache from '../cache/redis.cache';
 import PhaseQueue from '../queue/PhaseQueue';
 import QuizSettings from '../class/quizSettings';
 import { quizSettingInstance } from '../services/init-services';

--- a/apps/server/src/sockets/ParticipantManager.ts
+++ b/apps/server/src/sockets/ParticipantManager.ts
@@ -9,7 +9,7 @@ import {
 import { CustomWebSocket } from '../types/web-socket-types';
 import { v4 as uuid } from 'uuid';
 import DatabaseQueue from '../queue/DatabaseQueue';
-import RedisCache from '../cache/RedisCache';
+import RedisCache from '../cache/redis.cache';
 import { prisma, QuizPhase } from '@nocturn/database';
 import WebSocket from 'ws';
 import { socket_codes } from '@nocturn/types';
@@ -461,9 +461,8 @@ export default class ParticipantManager {
 
         const quiz = await this.redis_cache.get_quiz(game_session_id);
         const participant = await this.redis_cache.get_participant(game_session_id, participant_id);
-
-        if (!quiz) {
-            console.error('Quiz not found');
+        if (!quiz || !participant) {
+            console.error('Quiz or participant not found');
             return;
         }
 
@@ -547,7 +546,7 @@ export default class ParticipantManager {
         try {
             const new_warning_count = await this.redis_cache.redis_cache.hincrby(
                 participants_key,
-                `${participant_id}.warningCount`,
+                `${participant_id}:warningCount`,
                 1,
             );
 

--- a/apps/server/src/sockets/QuizManager.ts
+++ b/apps/server/src/sockets/QuizManager.ts
@@ -1,5 +1,5 @@
 import Redis from 'ioredis';
-import RedisCache from '../cache/RedisCache';
+import RedisCache from '../cache/redis.cache';
 import { Participant, QuizStatus, SessionStatus, Spectator, prisma } from '@nocturn/database';
 import { CookiePayload, MESSAGE_TYPES, PubSubMessageTypes, SECONDS } from '@nocturn/types';
 import { PhaseQueueJobDataType } from '../types/web-socket-types';

--- a/apps/server/src/sockets/SpectatorManager.ts
+++ b/apps/server/src/sockets/SpectatorManager.ts
@@ -12,7 +12,7 @@ import QuizManager from './QuizManager';
 import { prisma } from '@nocturn/database';
 import { v4 as uuid } from 'uuid';
 import DatabaseQueue from '../queue/DatabaseQueue';
-import RedisCache from '../cache/RedisCache';
+import RedisCache from '../cache/redis.cache';
 import QuizSettings from '../class/quizSettings';
 import { quizSettingInstance } from '../services/init-services';
 import { WebSocket } from 'ws';

--- a/apps/server/src/sockets/socket.server.ts
+++ b/apps/server/src/sockets/socket.server.ts
@@ -5,7 +5,7 @@ import { parse } from 'cookie';
 import jwt from 'jsonwebtoken';
 import HostManager from './HostManager';
 import QuizManager from './QuizManager';
-import RedisCache from '../cache/RedisCache';
+import RedisCache from '../cache/redis.cache';
 import { URL } from 'url';
 import ParticipantManager from './ParticipantManager';
 import SpectatorManager from './SpectatorManager';

--- a/apps/web/src/components/canvas/Canvas.tsx
+++ b/apps/web/src/components/canvas/Canvas.tsx
@@ -8,7 +8,7 @@ import CanvasHeading from './CanvasHeading';
 import Image from 'next/image';
 import CanvasOptions from './CanvasOptions';
 import { getImageContainerWidth, useWidth } from '@/hooks/useWidth';
-import useLiveTemplate from '@/hooks/useLiveTemplate';
+import { templates } from '@/lib/templates';
 
 export enum SELECTION_MODE {
     CANVAS = 'CANVAS',
@@ -24,7 +24,7 @@ export default function Canvas(): JSX.Element {
     const canvasRef = useRef<HTMLDivElement>(null);
     const { currentQuestionIndex, quiz } = useNewQuizStore();
     const currentQ = quiz.questions[currentQuestionIndex];
-    const template = useLiveTemplate();
+    const template = templates.find((t) => t.id === quiz.theme);
     const canvasWidth = useWidth(canvasRef);
 
     useEffect(() => {


### PR DESCRIPTION
Found a tricky Redis bug: storing data as JSON strings breaks HINCRBY atomic operations. 
HINCRBY key "userId.warningCount" 1 creates a new field instead of updating the JSON! 
Solution: store each property as separate hash fields (userId:warningCount) for true atomic increments.